### PR TITLE
Optimize Pull Movements Logic

### DIFF
--- a/app/jobs/pull_account_movements_job.rb
+++ b/app/jobs/pull_account_movements_job.rb
@@ -6,7 +6,7 @@ class PullAccountMovementsJob < ApplicationJob
 
     ## https://github.com/EduardoSimon/budget.io/issues/29
     result = OpenBankingConnector.new.fetch_movements(
-      external_account_id: account.external_account_id
+      account: account
     )
 
     Rails.logger.info({balance: result.balance})

--- a/app/services/open_banking_connector.rb
+++ b/app/services/open_banking_connector.rb
@@ -99,9 +99,9 @@ class OpenBankingConnector
 
   def get_transactions_response(external_account:, account:)
     last_movement_date = account
-                          .movements
-                          .order(:created_at)
-                          .last&.created_at
+      .movements
+      .order(:created_at)
+      .last&.created_at
 
     date_from = (last_movement_date || 4.months.ago).strftime("%F")
     date_to = Time.now.strftime("%F")

--- a/app/services/open_banking_connector.rb
+++ b/app/services/open_banking_connector.rb
@@ -33,10 +33,11 @@ class OpenBankingConnector
     AuthSession.new(id: id, url: response[:link], accounts: response[:accounts], status: :succeeded)
   end
 
-  def fetch_movements(external_account_id:)
-    account = client.account(external_account_id)
+  def fetch_movements(account:)
+    external_account_id = account.external_account_id
+    external_account = client.account(external_account_id)
 
-    balances_response = account.get_balances.deep_symbolize_keys
+    balances_response = external_account.get_balances.deep_symbolize_keys
 
     raise StandardError.new(balances_response.to_json) if balances_response[:status_code] && balances_response[:status_code] >= 400
 
@@ -54,14 +55,9 @@ class OpenBankingConnector
 
     raise StandardError.new({message: "balances object was empty", params: main_balance}) if main_balance.nil?
 
-    seconds_in_day = 60 * 60 * 24
-    previous_month = Time.now - (seconds_in_day * 30 * 4)
-    get_transactions_response = account.get_transactions(
-      date_from: previous_month.strftime("%F"),
-      date_to: Time.now.strftime("%F")
-    ).deep_symbolize_keys
+    transactions_response = get_transactions_response(external_account:, account:)
 
-    transactions = get_transactions_response[:transactions]
+    transactions = transactions_response[:transactions]
     raise StandardError.new({message: "No transactions object found"}) unless transactions
 
     booked_transactions = transactions[:booked]
@@ -99,5 +95,20 @@ class OpenBankingConnector
   def auth_token_invalid?
     return true if @token_response.nil?
     @token_response[:last_fetch_timestamp] + @token_response.dig(:token_response, :access_expires) <= Time.now.to_i
+  end
+
+  def get_transactions_response(external_account:, account:)
+    last_movement_date = account
+                          .movements
+                          .order(:created_at)
+                          .last&.created_at
+
+    date_from = (last_movement_date || 4.months.ago).strftime("%F")
+    date_to = Time.now.strftime("%F")
+
+    external_account.get_transactions(
+      date_from:,
+      date_to:
+    ).deep_symbolize_keys
   end
 end

--- a/test/services/open_banking_connector_spec.rb
+++ b/test/services/open_banking_connector_spec.rb
@@ -6,8 +6,8 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
     setup do
       @client_mock = Minitest::Mock.new
       @client_mock.expect(:generate_token, "wadus")
-      @account_instance = create(:account, external_account_id: '1')
-      @current_date = DateTime.now.strftime('%F')
+      @account_instance = create(:account, external_account_id: "1")
+      @current_date = DateTime.now.strftime("%F")
       freeze_time
     end
 
@@ -31,7 +31,7 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
     end
 
     test "When no movement is present, then returns the main balance of the given existent account as a float number, the currency and the transactions for last 4 months" do
-      date_from = 4.months.ago.strftime('%F')
+      date_from = 4.months.ago.strftime("%F")
       date_to = @current_date
 
       balances_response = {"balances" => [{"balanceAmount" => {"amount" => "896.13", "currency" => "EUR"}, "balanceType" => "information", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}, {"balanceAmount" => {"amount" => "935.37", "currency" => "EUR"}, "balanceType" => "interimBooked", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}]}
@@ -60,10 +60,10 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
       end
     end
 
-    test 'When movement is present, then returns the main balance of the given existent account as a float number, the currency and the transactions from last moment onwards' do
+    test "When movement is present, then returns the main balance of the given existent account as a float number, the currency and the transactions from last moment onwards" do
       create(:movement, account_id: @account_instance.id, created_at: 2.days.ago)
       create(:movement, account_id: @account_instance.id, created_at: 1.days.ago)
-      last_movement_date = @account_instance.movements.last.created_at.strftime('%F')
+      last_movement_date = @account_instance.movements.last.created_at.strftime("%F")
 
       balances_response = {"balances" => [{"balanceAmount" => {"amount" => "896.13", "currency" => "EUR"}, "balanceType" => "information", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}, {"balanceAmount" => {"amount" => "935.37", "currency" => "EUR"}, "balanceType" => "interimBooked", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}]}
       account_mock = Minitest::Mock.new
@@ -89,7 +89,6 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
         assert_equal response.transactions.second[:date], "2023-07-24"
         assert_equal response.transactions.second[:description], "Pago en EL CORTE INGLES"
       end
-
     end
   end
 end

--- a/test/services/open_banking_connector_spec.rb
+++ b/test/services/open_banking_connector_spec.rb
@@ -30,7 +30,7 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
       end
     end
 
-    test "When no moments are present, then returns the main balance of the given existent account as a float number, the currency and the transactions for last 4 months" do
+    test "When no movement is present, then returns the main balance of the given existent account as a float number, the currency and the transactions for last 4 months" do
       date_from = 4.months.ago.strftime('%F')
       date_to = @current_date
 
@@ -60,7 +60,7 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
       end
     end
 
-    test 'When moments are present, then returns the main balance of the given existent account as a float number, the currency and the transactions from last moment onwards' do
+    test 'When movement is present, then returns the main balance of the given existent account as a float number, the currency and the transactions from last moment onwards' do
       create(:movement, account_id: @account_instance.id, created_at: 2.days.ago)
       create(:movement, account_id: @account_instance.id, created_at: 1.days.ago)
       last_movement_date = @account_instance.movements.last.created_at.strftime('%F')

--- a/test/services/open_banking_connector_spec.rb
+++ b/test/services/open_banking_connector_spec.rb
@@ -7,6 +7,7 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
       @client_mock = Minitest::Mock.new
       @client_mock.expect(:generate_token, "wadus")
       @account_instance = create(:account, external_account_id: '1')
+      @current_date = DateTime.now.strftime('%F')
       freeze_time
     end
 
@@ -29,18 +30,21 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
       end
     end
 
-    test "returns the main balance of the given existent account as a float number, the currency and the transactions" do
-      balances_response = {"balances" => [{"balanceAmount" => {"amount" => "896.13", "currency" => "EUR"}, "balanceType" => "information", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}, {"balanceAmount" => {"amount" => "935.37", "currency" => "EUR"}, "balanceType" => "interimBooked", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}]}
+    test "When no moments are present, then returns the main balance of the given existent account as a float number, the currency and the transactions for last 4 months" do
+      date_from = 4.months.ago.strftime('%F')
+      date_to = @current_date
 
+      balances_response = {"balances" => [{"balanceAmount" => {"amount" => "896.13", "currency" => "EUR"}, "balanceType" => "information", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}, {"balanceAmount" => {"amount" => "935.37", "currency" => "EUR"}, "balanceType" => "interimBooked", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}]}
       account_mock = Minitest::Mock.new
       account_mock.expect(:get_balances, balances_response.deep_symbolize_keys)
-      account_mock.expect(:get_transactions, {"transactions" => {"booked" => MockClient::Stubs.transactions}}, date_from: String, date_to: String)
+      account_mock.expect(:get_transactions, {"transactions" => {"booked" => MockClient::Stubs.transactions}}, date_from:, date_to:)
 
       @client_mock.expect(:account, account_mock, ["1"])
 
       ::Nordigen::NordigenClient.stub(:new, @client_mock) do
         response = OpenBankingConnector.new.fetch_movements(account: @account_instance)
 
+        assert_equal @account_instance.movements.exists?, false
         assert_equal response.balance, 896.13
         assert_equal response.currency, "EUR"
 
@@ -54,6 +58,38 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
         assert_equal response.transactions.second[:date], "2023-07-24"
         assert_equal response.transactions.second[:description], "Pago en EL CORTE INGLES"
       end
+    end
+
+    test 'When moments are present, then returns the main balance of the given existent account as a float number, the currency and the transactions from last moment onwards' do
+      create(:movement, account_id: @account_instance.id, created_at: 2.days.ago)
+      create(:movement, account_id: @account_instance.id, created_at: 1.days.ago)
+      last_movement_date = @account_instance.movements.last.created_at.strftime('%F')
+
+      balances_response = {"balances" => [{"balanceAmount" => {"amount" => "896.13", "currency" => "EUR"}, "balanceType" => "information", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}, {"balanceAmount" => {"amount" => "935.37", "currency" => "EUR"}, "balanceType" => "interimBooked", "lastChangeDateTime" => "2023-10-12T00:00:00Z"}]}
+      account_mock = Minitest::Mock.new
+      account_mock.expect(:get_balances, balances_response.deep_symbolize_keys)
+      account_mock.expect(:get_transactions, {"transactions" => {"booked" => MockClient::Stubs.transactions}}, date_from: last_movement_date, date_to: @current_date)
+
+      @client_mock.expect(:account, account_mock, ["1"])
+
+      ::Nordigen::NordigenClient.stub(:new, @client_mock) do
+        response = OpenBankingConnector.new.fetch_movements(account: @account_instance)
+
+        assert_equal @account_instance.movements.exists?, true
+        assert_equal response.balance, 896.13
+        assert_equal response.currency, "EUR"
+
+        assert_equal response.transactions.first[:id], 0
+        assert_equal response.transactions.first[:amount], 100.0
+        assert_equal response.transactions.first[:date], "2023-07-24"
+        assert_equal response.transactions.first[:description], "Pago en EL CORTE INGLES"
+
+        assert_equal response.transactions.second[:id], 1
+        assert_equal response.transactions.second[:amount], 200.0
+        assert_equal response.transactions.second[:date], "2023-07-24"
+        assert_equal response.transactions.second[:description], "Pago en EL CORTE INGLES"
+      end
+
     end
   end
 end

--- a/test/services/open_banking_connector_spec.rb
+++ b/test/services/open_banking_connector_spec.rb
@@ -6,6 +6,7 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
     setup do
       @client_mock = Minitest::Mock.new
       @client_mock.expect(:generate_token, "wadus")
+      @account_instance = create(:account, external_account_id: '1')
       freeze_time
     end
 
@@ -21,7 +22,7 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
 
       ::Nordigen::NordigenClient.stub(:new, @client_mock) do
         exception = assert_raises(StandardError) do |e|
-          OpenBankingConnector.new.fetch_movements(external_account_id: "1")
+          OpenBankingConnector.new.fetch_movements(account: @account_instance)
         end
 
         assert_equal exception.message, error.to_json
@@ -38,7 +39,7 @@ class OpenBankingConnectorTest < ActiveSupport::TestCase
       @client_mock.expect(:account, account_mock, ["1"])
 
       ::Nordigen::NordigenClient.stub(:new, @client_mock) do
-        response = OpenBankingConnector.new.fetch_movements(external_account_id: "1")
+        response = OpenBankingConnector.new.fetch_movements(account: @account_instance)
 
         assert_equal response.balance, 896.13
         assert_equal response.currency, "EUR"


### PR DESCRIPTION
- This PR optimizes the logic for the _movements_ pulled into the application by reducing the amount of over-fetching
- Now we only fetch new transactions from the date of the last pulled _movement_ till now
- If the current _account_ doesn't have any _movements_, we are then using the previously implemented date range i.e. last 4 months' transactions.

Resolves #29 