### PR TITLE
Improve the Application Setup Steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: prepare
 prepare:
-	bundle exec rake assets:precompile
-	bundle exec rails db:create db:migrate db:seed
+	bundle install #install dependencies
+	bundle exec rake assets:precompile # build Rails Asset pipeline
+	bundle exec rails db:prepare # create, migrate and seed database
 
 .PHONY: up
 up: prepare

--- a/README.md
+++ b/README.md
@@ -13,21 +13,22 @@ Use a ruby dependency manager like rbenv or asdf. The supported ruby version is 
 
 ## Setup
 
-1. Install dependencies
-
-`bundle install`
-
-2. Install postgres
+1. Install postgres
 
 `brew install postgresql`
 
-3. Run postgres as a brew service
+2. Run postgres as a brew service
 
 `brew services start postgresql`
 
-4. Prepare dabatase
+3. Install Make
 
-`bin/rails db:create db:migrate db:seed`
+`brew install make`
+
+4. Prepare the development environment
+
+`make prepare`
+
 
 5. Run the server
 


### PR DESCRIPTION
**Resolves #37 (Missing Step for Asset Compilation in the README.md)**

This PR improves the application setup steps by following changes:
  - Leverage the `make prepare` to prepare the development environment because We are already using asset compilation here.
  - Moreover, we can further improve this step the following changes:
    - Add `bundle install` step
    - Replace `rails db:create db:migrate db:seed` with `rails db:prepare`
  - Add the make prepare step in the README