### PR TITLE
chore: adapt database name to repository name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,7 @@ ruby-lint:
 	bundle exec rake factory_bot:lint
 	bundle exec standardrb
 
+.PHONY: pg-shell
+pg-shell:
+	$(DOCKER_BIN) up --build -d
+	$(DOCKER_BIN) exec -it db psql -U postgres

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,15 +7,15 @@ default: &default
 
 development:
   <<: *default
-  database: ynab-clone-dev
+  database: budget-io-dev
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: ynab-clone-test
+  database: budget-io-test
 
 production:
   <<: *default
-  database: ynab-clone-prod
+  database: budget-io-prod


### PR DESCRIPTION
A new makefile target has been added to connect to the postgres instance.

This is a BREAKING CHANGE for anyone using the app in a production environment.

The steps to fix it are:
1. Create a dump. `pg_dump <your_posgtres> ynab-clone-prod > prod_dump`
2. Initialize the app pointing to main. This will create an empty database.
3. Feed that dump into the newly created db. `psql --set ON_ERROR_STOP=on budget-io-prod < prod_dump`